### PR TITLE
fix private msg bug, update backen plugin params

### DIFF
--- a/cqapi.go
+++ b/cqapi.go
@@ -164,5 +164,5 @@ func MakePrivateMsg(msgBuilder MsgBuilder, userID int64) ApiPost {
 		AutoEscape: false,
 		Message:    msgData,
 	}
-	return makeApi(GroupMsgAction, msg)
+	return makeApi(PrivateMsgAction, msg)
 }

--- a/plugin.go
+++ b/plugin.go
@@ -89,7 +89,7 @@ func (p *Plugin) AddRequestUnit() *RequestUnit {
 type BackenUnit struct {
 	Plg   *Plugin
 	Init  func()
-	Start func(bots BotCtxs)
+	Start func(bInfos []BotInfo)
 }
 
 func (bp *BackenUnit) SetInitFunc(f func()) *BackenUnit {
@@ -97,7 +97,7 @@ func (bp *BackenUnit) SetInitFunc(f func()) *BackenUnit {
 	return bp
 }
 
-func (bp *BackenUnit) SetStartFunc(f func(bots []BotContext)) *BackenUnit {
+func (bp *BackenUnit) SetStartFunc(f func(bInfos []BotInfo)) *BackenUnit {
 	bp.Start = f
 	return bp
 }

--- a/server.go
+++ b/server.go
@@ -148,7 +148,7 @@ func doEchoCallback(apiResp *ApiResp, bCtx *BotContext) {
 func InitBackenPlugin() {
 	for _, bp := range BackenChain {
 		bp.Init()
-		go bp.Start(bots)
+		go bp.Start(Conf.BotInfos)
 	}
 }
 


### PR DESCRIPTION
- 修改后台插件传入参数为botInfo，不包含通道、ws连接等信息。
- 修复private msg api的action参数为group msg的问题